### PR TITLE
feat: display battery percent on summary screen

### DIFF
--- a/app/src/main/java/com/example/deviceinfo/dataitems/BatteryCapacityData.kt
+++ b/app/src/main/java/com/example/deviceinfo/dataitems/BatteryCapacityData.kt
@@ -1,0 +1,12 @@
+package com.example.deviceinfo.dataitems
+
+import android.os.BatteryManager
+import com.example.deviceinfo.R
+
+/**
+ * Provides information on the current battery capacity of the current device.
+ */
+class BatteryCapacityData(batteryManager: BatteryManager) : SimpleListItem(
+    R.string.battery_capacity,
+    batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY).toString()
+)

--- a/app/src/main/java/com/example/deviceinfo/first/SummaryFragment.kt
+++ b/app/src/main/java/com/example/deviceinfo/first/SummaryFragment.kt
@@ -22,7 +22,7 @@ class SummaryFragment : Fragment(R.layout.fragment_list) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        groupAdapter += viewModel.dataItems
+        groupAdapter += viewModel.getDataItems(requireContext())
         view.findViewById<RecyclerView>(R.id.firstRecyclerView).apply {
             adapter = groupAdapter
             layoutManager = LinearLayoutManager(requireContext())

--- a/app/src/main/java/com/example/deviceinfo/first/SummaryViewModel.kt
+++ b/app/src/main/java/com/example/deviceinfo/first/SummaryViewModel.kt
@@ -1,6 +1,10 @@
 package com.example.deviceinfo.first
 
+import android.content.Context
+import android.content.Context.BATTERY_SERVICE
+import android.os.BatteryManager
 import androidx.lifecycle.ViewModel
+import com.example.deviceinfo.dataitems.BatteryCapacityData
 import com.example.deviceinfo.dataitems.ManufacturerData
 import com.xwray.groupie.Section
 
@@ -8,12 +12,18 @@ import com.xwray.groupie.Section
  * A ViewModel for use with the [SummaryFragment].
  */
 class SummaryViewModel : ViewModel() {
+
     /**
-     * The list of data items to display to the user.
+     * Generates the list of data items to display to the user.
      */
-    val dataItems = listOf(
+    fun getDataItems(context: Context) = listOf(
         Section(
-            ManufacturerData()
+            listOf(
+                ManufacturerData(),
+                BatteryCapacityData(
+                    requireNotNull(context.getSystemService(BATTERY_SERVICE) as? BatteryManager)
+                )
+            )
         )
     )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,7 @@
     <string name="summary_fragment_label">Summary Fragment</string>
 
     <string name="manufacturer">Manufacturer</string>
+
+    <!-- Battery -->
+    <string name="battery_capacity">Battery Capacity</string>
 </resources>


### PR DESCRIPTION
Pull out the battery percent on the summary screen and display it,
this required making a change to pass the context into the get
method, which can be removed again when we integrate dagger into
the project

closes #8

![Screenshot_1602278351](https://user-images.githubusercontent.com/5438952/95632512-ad52b300-0a7d-11eb-98bf-c7ae94e0741a.png)
