### PR TITLE
add dark theme

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.0'
     implementation "com.xwray:groupie:$groupie_version"
     implementation "com.xwray:groupie-kotlin-android-extensions:$groupie_version"
-    implementation "androidx.preference:preference:1.1.1"
+    implementation "androidx.preference:preference-ktx:1.1.1"
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.0'
     implementation "com.xwray:groupie:$groupie_version"
     implementation "com.xwray:groupie-kotlin-android-extensions:$groupie_version"
-    implementation "androidx.preference:preference:1.1.0"
+    implementation "androidx.preference:preference:1.1.1"
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.0'
     implementation "com.xwray:groupie:$groupie_version"
     implementation "com.xwray:groupie-kotlin-android-extensions:$groupie_version"
+    implementation "androidx.preference:preference:1.1.0"
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,8 +11,7 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.example.deviceinfo">
 
     <application
+        android:name=".App"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/com/example/deviceinfo/App.kt
+++ b/app/src/main/java/com/example/deviceinfo/App.kt
@@ -1,0 +1,20 @@
+package com.example.deviceinfo
+
+import android.app.Application
+import androidx.preference.PreferenceManager
+
+/**
+ * Main entry point of the application.
+ */
+class App : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
+        val themePref = sharedPreferences.getString(
+            getString(R.string.theme_key),
+            ThemeHelper.DEFAULT_MODE
+        )
+        ThemeHelper.applyTheme(themePref!!)
+    }
+}

--- a/app/src/main/java/com/example/deviceinfo/MainActivity.kt
+++ b/app/src/main/java/com/example/deviceinfo/MainActivity.kt
@@ -3,7 +3,9 @@ package com.example.deviceinfo
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.navigation.findNavController
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
 
@@ -24,17 +26,20 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
-        // Inflate the menu; this adds items to the action bar if it is present.
         menuInflater.inflate(R.menu.menu_main, menu)
         return true
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        // Handle action bar item clicks here. The action bar will
-        // automatically handle clicks on the Home/Up button, so long
-        // as you specify a parent activity in AndroidManifest.xml.
         return when (item.itemId) {
-            R.id.action_settings -> true
+            R.id.action_settings -> {
+                findViewById<View>(R.id.nav_host_fragment).findNavController().apply {
+                    if (currentDestination?.id != R.id.settingsFragment) {
+                        navigate(R.id.toSettingsFragment)
+                    }
+                }
+                true
+            }
             else -> super.onOptionsItemSelected(item)
         }
     }

--- a/app/src/main/java/com/example/deviceinfo/ThemeHelper.kt
+++ b/app/src/main/java/com/example/deviceinfo/ThemeHelper.kt
@@ -1,0 +1,30 @@
+package com.example.deviceinfo
+
+import android.os.Build
+import androidx.appcompat.app.AppCompatDelegate
+
+/**
+ * Helper class for working with Day Night themes.
+ *
+ */
+object ThemeHelper {
+    private const val DAY_THEME = "Day"
+    private const val NIGHT_THEME = "Night"
+    const val DEFAULT_MODE = "System"
+
+    /**
+     * Apply a theme to the app.
+     */
+    fun applyTheme(themePref: String) {
+        when (themePref) {
+            DAY_THEME -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+            NIGHT_THEME -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+            else ->
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
+                } else {
+                    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY)
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/example/deviceinfo/first/SummaryFragment.kt
+++ b/app/src/main/java/com/example/deviceinfo/first/SummaryFragment.kt
@@ -22,6 +22,7 @@ class SummaryFragment : Fragment(R.layout.fragment_list) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        groupAdapter.clear()
         groupAdapter += viewModel.getDataItems(requireContext())
         view.findViewById<RecyclerView>(R.id.firstRecyclerView).apply {
             adapter = groupAdapter

--- a/app/src/main/java/com/example/deviceinfo/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/example/deviceinfo/settings/SettingsFragment.kt
@@ -1,0 +1,38 @@
+package com.example.deviceinfo.settings
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.preference.ListPreference
+import androidx.preference.PreferenceFragmentCompat
+import com.example.deviceinfo.R
+
+/**
+ * A fragment used to display settings to the user.
+ */
+class SettingsFragment : PreferenceFragmentCompat() {
+    private val themes: Map<String, Int>
+        get() {
+            val values = resources.getStringArray(R.array.themes)
+            return mapOf(
+                values[0] to AppCompatDelegate.MODE_NIGHT_NO,
+                values[1] to AppCompatDelegate.MODE_NIGHT_YES,
+                values[2] to AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+            )
+        }
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.preferences, rootKey)
+        findPreference<ListPreference>(getString(R.string.theme_key))
+            ?.setOnPreferenceChangeListener { _, newValue ->
+                handleThemeSelection(themes, newValue as? String)
+                true
+            }
+    }
+
+    private fun handleThemeSelection(themes: Map<String, Int>, selection: String?) {
+        if (selection == null) return
+        val selectionId = themes[selection] ?: return
+
+        AppCompatDelegate.setDefaultNightMode(selectionId)
+    }
+}

--- a/app/src/main/java/com/example/deviceinfo/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/example/deviceinfo/settings/SettingsFragment.kt
@@ -1,38 +1,28 @@
 package com.example.deviceinfo.settings
 
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceFragmentCompat
 import com.example.deviceinfo.R
+import com.example.deviceinfo.ThemeHelper
 
 /**
  * A fragment used to display settings to the user.
  */
 class SettingsFragment : PreferenceFragmentCompat() {
-    private val themes: Map<String, Int>
-        get() {
-            val values = resources.getStringArray(R.array.themes)
-            return mapOf(
-                values[0] to AppCompatDelegate.MODE_NIGHT_NO,
-                values[1] to AppCompatDelegate.MODE_NIGHT_YES,
-                values[2] to AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-            )
-        }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.preferences, rootKey)
         findPreference<ListPreference>(getString(R.string.theme_key))
             ?.setOnPreferenceChangeListener { _, newValue ->
-                handleThemeSelection(themes, newValue as? String)
+                handleThemeSelection(newValue as? String)
                 true
             }
     }
 
-    private fun handleThemeSelection(themes: Map<String, Int>, selection: String?) {
+    private fun handleThemeSelection(selection: String?) {
         if (selection == null) return
-        val selectionId = themes[selection] ?: return
 
-        AppCompatDelegate.setDefaultNightMode(selectionId)
+        ThemeHelper.applyTheme(selection)
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,15 +8,12 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:theme="@style/AppTheme.AppBarOverlay">
+        android:layout_height="wrap_content">
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:background="?attr/colorPrimary"
-            app:popupTheme="@style/AppTheme.PopupOverlay" />
+            android:layout_height="?attr/actionBarSize" />
 
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -12,6 +12,7 @@
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
+            style="@style/Widget.MaterialComponents.Toolbar.Primary"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize" />
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,7 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <androidx.appcompat.widget.Toolbar
+        <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize" />

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -9,5 +9,13 @@
         android:id="@+id/SummaryFragment"
         android:name="com.example.deviceinfo.first.SummaryFragment"
         android:label="@string/summary_fragment_label"
-        tools:layout="@layout/fragment_list" />
+        tools:layout="@layout/fragment_list" >
+        <action
+            android:id="@+id/toSettingsFragment"
+            app:destination="@id/settingsFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/settingsFragment"
+        android:name="com.example.deviceinfo.settings.SettingsFragment"
+        android:label="SettingsFragment" />
 </navigation>

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="theme_key">com.example.deviceinfo.theme</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,11 @@
 
     <!-- Battery -->
     <string name="battery_capacity">Battery Capacity</string>
+    <string name="theme_title">App Theme</string>
+
+    <string-array name="themes">
+        <item>Day</item>
+        <item>Night</item>
+        <item>System</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,4 +1,4 @@
-    <resources>
+<resources>
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Customize your theme here. -->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,19 +1,9 @@
-<resources>
+    <resources>
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
     </style>
-
-    <style name="AppTheme.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
-    </style>
-
-    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
-
-    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
-
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.preference.PreferenceScreen  xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
+    <ListPreference
+        android:title="@string/theme_title"
+        android:key="@string/theme_key"
+        android:defaultValue="3"
+        android:entries="@array/themes"
+        android:entryValues="@array/themes" />
+</androidx.preference.PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.preference.PreferenceScreen  xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_height="match_parent"
-    android:layout_width="match_parent">
+<androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
     <ListPreference
-        android:title="@string/theme_title"
-        android:key="@string/theme_key"
-        android:defaultValue="3"
-        android:entries="@array/themes"
-        android:entryValues="@array/themes" />
+        app:useSimpleSummaryProvider="true"
+        app:defaultValue="System"
+        app:entries="@array/themes"
+        app:entryValues="@array/themes"
+        app:key="@string/theme_key"
+        app:title="@string/theme_title" />
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Add support for dark theme with support for the user to change the theme in the app. The overflow menu in the day theme is white rather than the toolbar colour, the [plaid app](https://github.com/android/plaid) has the same behaviour.

![image](https://user-images.githubusercontent.com/8459796/97083908-47ccfd80-160b-11eb-8c7c-a8092ed4e485.png)
![image](https://user-images.githubusercontent.com/8459796/97083913-4f8ca200-160b-11eb-8eb9-c032d573fe25.png)
![image](https://user-images.githubusercontent.com/8459796/97083918-53202900-160b-11eb-957b-ac489d5ff82c.png)
