### PR TITLE
ci: allow danger to execute from forked repos

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -47,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: set up JDK 1.8
       uses: actions/setup-java@v1.4.2
       with:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  pull_request_target:
+    branches: [ master ]
 
 jobs:
   test:
@@ -43,7 +45,7 @@ jobs:
 
   danger:
     needs: [test, analyze]
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,8 +3,6 @@ name: Android CI
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
   pull_request_target:
     branches: [ master ]
 
@@ -13,6 +11,10 @@ jobs:
    runs-on: ubuntu-latest
    steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
+        fetch-depth: 0
     - name: set up JDK 1.8
       uses: actions/setup-java@v1.4.2
       with:
@@ -27,6 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
+        fetch-depth: 0
     - name: set up JDK 1.8
       uses: actions/setup-java@v1.4.2
       with:
@@ -50,6 +56,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
         fetch-depth: 0
     - name: set up JDK 1.8
       uses: actions/setup-java@v1.4.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     colored2 (3.1.2)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (8.0.5)
+    danger (8.2.0)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
@@ -32,13 +32,11 @@ GEM
     danger-checkstyle_format (0.1.1)
       danger-plugin-api (~> 1.0)
       ox (~> 2.0)
-    danger-junit (1.0.2)
-      danger (> 2.0)
-      ox (~> 2.0)
     danger-plugin-api (1.0.0)
       danger (> 2.0)
-    faraday (1.0.1)
+    faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
+      ruby2_keywords
     faraday-http-cache (2.2.0)
       faraday (>= 0.8)
     git (1.7.0)
@@ -50,7 +48,7 @@ GEM
     multipart-post (2.1.1)
     nap (1.1.0)
     no_proxy_fix (0.1.2)
-    octokit (4.18.0)
+    octokit (4.19.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     oga (3.2)
@@ -58,12 +56,13 @@ GEM
       ruby-ll (~> 2.1)
     open4 (1.3.4)
     ox (2.13.2)
-    public_suffix (4.0.5)
+    public_suffix (4.0.6)
     rchardet (1.8.0)
     rexml (3.2.4)
     ruby-ll (2.1.2)
       ansi
       ast
+    ruby2_keywords (0.0.2)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
@@ -78,7 +77,6 @@ DEPENDENCIES
   danger
   danger-android_lint
   danger-checkstyle_format
-  danger-junit
 
 BUNDLED WITH
    2.1.2


### PR DESCRIPTION
Add the fetch-depth param with value of 0 when checking out which
should allow forks to run danger, as per
https://github.com/danger/danger/issues/1103#issuecomment-635539947